### PR TITLE
Handle dependencies that contain a dot

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,7 @@ exports.lint = function(opts) {
     var parent = this;
     var requires = detective(str)
     requires.forEach(function(req) {
-      if (req.match(/\./)) {
+      if (req.match(/^\./)) {
         Module._load(req, parent);
       } else {
         var core = builtins.indexOf(req) > -1;

--- a/test/recursive/index.js
+++ b/test/recursive/index.js
@@ -6,3 +6,6 @@ require('lodash');
 
 // require relative module
 require('./lib');
+
+// require missing dependency with a . in it
+require('big.js');

--- a/test/tests.js
+++ b/test/tests.js
@@ -48,7 +48,7 @@ describe('require lint', function() {
         pkg: __dirname + '/recursive/package.json'
       });
       report.should.eql({
-        missing: ['lodash', 'express'],
+        missing: ['lodash', 'express', 'big.js'],
         extra: []
       });
     });


### PR DESCRIPTION
@TabDigital/api

Was reporting dependencies that contain a `.` character as extraneous
