### PR TITLE
Now that you can choose to ignore them, fail lint if there are extra dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@
 Parses your code for `require` statements, and checks that:
 
 - all required dependencies are mentioned in `package.json`
-- all depedencies in `package.json` are still being used
+- all dependencies in `package.json` are still being used
 
 ```
 $ npm install -g require-lint
 $ require-lint
 
-[WARN] Extraneous dependencies: lodash
-[ERROR] Missing dependencies: attempt, express
+[require-lint] Missing dependencies: attempt, express
+[require-lint] Extraneous dependencies: lodash
 ```
 
-Extraneous dependencies only print a warning, but missing dependencies trigger an exit code of `1`.
+Any failed checks will trigger an exit code of `1`, and you can choose to fail your build chain.
 
 *Note: require-lint doesn't check dev dependencies, since test code doesn't typically have a single entry point*
 

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -23,13 +23,18 @@ try {
     ignoreExtra: list(args['ignore-extra'])
   });
 
-  if (report.extra.length > 0) {
-    console.warn('[WARN] Extraneous dependencies:', report.extra.join(', '));
+  if (report.missing.length > 0) {
+    console.error('[require-lint] Missing dependencies:', report.missing.join(', '));
   }
 
-  if (report.missing.length > 0) {
-    console.error('[ERROR] Missing dependencies:', report.missing.join(', '));
-    throw new Error('Failed');
+  if (report.extra.length > 0) {
+    console.error('[require-lint] Extraneous dependencies:', report.extra.join(', '));
+  }
+
+  if (report.missing.length + report.extra.length > 0) {
+    process.exit(1);
+  } else {
+    console.log('[require-lint] OK')
   }
 
 } catch (ex) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -80,7 +80,7 @@ describe('require lint', function() {
       test([
         '--pkg ' + __dirname + '/extra/package.json'
       ], function(exitCode, stdout, stderr) {
-        exitCode.should.eql(0);
+        exitCode.should.be.above(0);
         stderr.should.contain('Extraneous dependencies: express');
         done();
       });


### PR DESCRIPTION
@TabDigital/api 

If there's any dependencies in `package.json` that aren't actually used, it will print

```
[require-lint] Extraneous dependencies: coffee-script
```

This used to just be a warning, but now that you can choose to ignore them with `--ignore-extra coffee-script`, it's probably better to fail the build if there's any leftover ones.

_Note: breaking change, so we should bump up to 1.0.0_
