### PR TITLE
Explicitly upgrade builtins because ^ doesn't work with 0.0.x releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "lodash": "^2.4.1",
     "detective": "^3.1.0",
-    "builtins": "^0.0.5",
+    "builtins": "^0.0.7",
     "minimist": "^0.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
@rprieto @nguyenchr 
